### PR TITLE
Listing dev

### DIFF
--- a/src/Ophis/Listing.py
+++ b/src/Ophis/Listing.py
@@ -41,6 +41,7 @@ class Listing(object):
         filelines = {}
         prevline = None
         prevfile = None
+        prevrow = None
         if self.filename == "-":
             out = sys.stdout
         else:
@@ -49,6 +50,7 @@ class Listing(object):
             if type(x) is str:
                 print(x, file=out)
             elif type(x) is list:
+                prevrow = None
                 curline = x[0].split('->')[0]
                 curfile, curln = curline.split(':')
                 curln = int(curln)
@@ -64,19 +66,31 @@ class Listing(object):
                 if not prevfile == curfile:
                     prevfile = curfile  
                     print("Source file: %s" % curfile, file=out)
-                srcline = filelines['curfile'][curln - 1]
+                srcline = filelines['curfile'][curln - 1].strip()
                 if prevline == curline:
                     print("%-32s" % (x[1]), file=out)
                 else:
                     prevline = curline
-                    print("%-32s %5d  %s" % (x[1], curln, srcline.strip()), file=out)
+                    print("%-32s %5d  %s" % (x[1], curln, srcline), file=out)
             elif type(x) is tuple:
+                prevline = None
                 i = 0
                 pc = x[0]
+                dupestring = None
+                prevrow = None
                 while True:
                     row = x[1][i:i + 16]
                     if row == []:
                         break
+                    if prevrow == row:
+                        i += 16
+                        if not dupestring:
+                            dupestring = "   . . ."
+                            print(dupestring, file=out)
+                        continue
+                    else:
+                        dupestring = None
+                        prevrow = row
                     dataline = " %04X " % (pc + i)
                     dataline += (" %02X" * len(row)) % tuple(row)
                     charline = ""

--- a/src/Ophis/Listing.py
+++ b/src/Ophis/Listing.py
@@ -58,11 +58,6 @@ class Listing(object):
                     openfiles.append(curfile)
                     with open(curfile, 'rt') as f:
                         filelines['curfile'] = f.read().splitlines()
-                    #print("=== %s" % curfile)
-                    #lnum = 0
-                    #for fileline in filelines['curfile']:
-                    #    lnum += 1
-                    #    print("%4d %s" % (lnum, fileline))
                 if not prevfile == curfile:
                     prevfile = curfile  
                     print("Source file: %s" % curfile, file=out)

--- a/src/Ophis/Listing.py
+++ b/src/Ophis/Listing.py
@@ -37,6 +37,10 @@ class Listing(object):
         self.listing[-1][1].extend(vals)
 
     def dump(self):
+        openfiles = []
+        filelines = {}
+        prevline = None
+        prevfile = None
         if self.filename == "-":
             out = sys.stdout
         else:
@@ -44,6 +48,28 @@ class Listing(object):
         for x in self.listing:
             if type(x) is str:
                 print(x, file=out)
+            elif type(x) is list:
+                curline = x[0].split('->')[0]
+                curfile, curln = curline.split(':')
+                curln = int(curln)
+                if not curfile in openfiles:
+                    openfiles.append(curfile)
+                    with open(curfile, 'rt') as f:
+                        filelines['curfile'] = f.read().splitlines()
+                    #print("=== %s" % curfile)
+                    #lnum = 0
+                    #for fileline in filelines['curfile']:
+                    #    lnum += 1
+                    #    print("%4d %s" % (lnum, fileline))
+                if not prevfile == curfile:
+                    prevfile = curfile  
+                    print("Source file: %s" % curfile, file=out)
+                srcline = filelines['curfile'][curln - 1]
+                if prevline == curline:
+                    print("%-32s" % (x[1]), file=out)
+                else:
+                    prevline = curline
+                    print("%-32s %5d  %s" % (x[1], curln, srcline.strip()), file=out)
             elif type(x) is tuple:
                 i = 0
                 pc = x[0]

--- a/src/Ophis/Passes.py
+++ b/src/Ophis/Passes.py
@@ -929,10 +929,10 @@ class Assembler(Pass):
                 self.outputbyte(expr, env, inst_bytes)
             elif arglen == 2:
                 self.outputword(expr, env, inst_bytes)
-        self.listing.listInstruction(self.listing_string(env.getPC(),
+        self.listing.listInstruction([node.ppt, self.listing_string(env.getPC(),
                                                          inst_bytes,
                                                          mode, opcode,
-                                                         val1, val2))
+                                                         val1, val2)])
         env.incPC(1 + arglen)
         self.code += 1 + arglen
 


### PR DESCRIPTION
I'm making a few changes to the listing output, including a little more information on source code and omitting repetitive blocks of bytes.

I'm currently using Ophis on Linux with the [Ben Eater 6502 breadboard computer](https://eater.net/6502), generating 32K EEPROM images for the breadboarded computer.  Thanks for the excellent assembler, I'm quite impressed with it so far; I was drawn to it for being open, implemented in Python, and portable.

Trying to be as unobtrusive to the non-listing code as possible.

Any suggestions welcomed.


